### PR TITLE
Mirage model & factory generator

### DIFF
--- a/addon/JSONAPIMirageModel.js
+++ b/addon/JSONAPIMirageModel.js
@@ -1,0 +1,19 @@
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
+import { singularize } from 'ember-inflector';
+
+export default function JSONAPIMirageModel(schema) {
+  return Model.extend(schemaParser(schema));
+}
+
+function schemaParser(schema) {
+  return Object.keys(schema).reduce((model, key) => {
+    var info = schema[key] || {};
+    var type = singularize(info.type);
+    if (info.relationship === 'hasMany') {
+      model[key] = hasMany(type);
+    } else if (info.relationship === 'belongsTo') {
+      model[key] = belongsTo(type);
+    }
+    return model;
+  }, {});
+}

--- a/app/JSONAPIMirageModel.js
+++ b/app/JSONAPIMirageModel.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+import JSONAPIMirageModel from 'ember-jsonapi/JSONAPIMirageModel';
+
+export default JSONAPIMirageModel;

--- a/app/JSONAPIModel.js
+++ b/app/JSONAPIModel.js
@@ -1,4 +1,4 @@
 import Ember from 'ember';
 import JSONAPIModel from 'ember-jsonapi/JSONAPIModel';
 
-export default JSONAPIModel
+export default JSONAPIModel;

--- a/blueprints/mirage-from-schema/files/mirage/factories/__name__.js
+++ b/blueprints/mirage-from-schema/files/mirage/factories/__name__.js
@@ -1,5 +1,5 @@
 import { Factory<%if (hasFaker){%>, faker<%}%> } from 'ember-cli-mirage';
 
-export default Factory.extend({<% fields.forEach(function(f, idx) { %>
-  "<%=f.name%>": <%if (f.fakerPath) {%>function() { return faker.<%= f.fakerPath %>(); }<%if (idx < fields.length - 1) {%>,<%}%><%} else {%>null<%}%>
+export default Factory.extend({
+<% fields.forEach(function(f, idx) { %>  "<%=f.name%>": <%if (f.fakerPath) {%>function() { return faker.<%= f.fakerPath %>(); }<%if (idx < fields.length - 1) {%>,<%}%><%} else {%>null<%}%>
 <% }) %>});

--- a/blueprints/mirage-from-schema/files/mirage/factories/__name__.js
+++ b/blueprints/mirage-from-schema/files/mirage/factories/__name__.js
@@ -1,0 +1,5 @@
+import { Factory<%if (hasFaker){%>, faker<%}%> } from 'ember-cli-mirage';
+
+export default Factory.extend({<% fields.forEach(function(f, idx) { %>
+  "<%=f.name%>": <%if (f.fakerPath) {%>function() { return faker.<%= f.fakerPath %>(); }<%if (idx < fields.length - 1) {%>,<%}%><%} else {%>null<%}%>
+<% }) %>});

--- a/blueprints/mirage-from-schema/files/mirage/models/__name__.js
+++ b/blueprints/mirage-from-schema/files/mirage/models/__name__.js
@@ -1,0 +1,4 @@
+import JSONAPIMirageModel from 'ember-jsonapi/JSONAPIMirageModel';
+import <%= schemaName %> from '<%= schemaPath %>';
+
+export default new JSONAPIMirageModel(<%= schemaName %>);

--- a/blueprints/mirage-from-schema/index.js
+++ b/blueprints/mirage-from-schema/index.js
@@ -56,9 +56,10 @@ module.exports = {
       return a;
     }, []);
 
+    var appName = this.project.pkg.name;
     var schemaName = this.schemaName();
     var modelName = this.modelName();
-    var schemaPath = '../../app/' + (options.pod ? modelName : 'schemas') + '/' + (options.pod ? 'schema' : schemaName);
+    var schemaPath = appName + '/' + (options.pod ? modelName : 'schemas') + '/' + (options.pod ? 'schema' : schemaName);
 
     return {
       fields: fields,

--- a/blueprints/mirage-from-schema/index.js
+++ b/blueprints/mirage-from-schema/index.js
@@ -1,0 +1,74 @@
+var inflection  = require('inflection');
+var SilentError = require('silent-error');
+var fs = require('fs');
+var path = require('path');
+
+function getFakerPath(field) {
+  var type = field ? field.type || field : null;
+  if (type === 'number') {
+    return 'random.number';
+  } else if (type === 'string') {
+    return 'random.words';
+  } else if (type === 'date') {
+    return 'date.recent';
+  } else if (type === 'boolean') {
+    return 'random.boolean';
+  }
+};
+
+module.exports = {
+  description: 'Creates a mirage factory and model for a JSONAPI schema',
+
+  anonymousOptions: [
+    'schema'
+  ],
+
+  schemaName: function() {
+    return inflection.pluralize(this.options.entity.name);
+  },
+  modelName() {
+    return inflection.singularize(this.options.entity.name);
+  },
+
+  schemaFile: function() {
+    var schemaName = this.schemaName();
+    var modelName = this.modelName();
+    var schemaPath = this.options.pod ? path.join(modelName, 'schema.json') : path.join('schemas', `${schemaName}.json`);
+    var appPath = this.options.target;
+    return path.join(appPath, 'app', schemaPath);
+  },
+
+  locals: function(options) {
+    try {
+      var schema = JSON.parse(fs.readFileSync(this.schemaFile()));
+    } catch (e) { throw new SilentError(`Migration ${schemaName} was not valid JSON: ${e.message}`); }
+    var hasFaker = false;
+    var fields = Object.keys(schema).reduce((a, k) => {
+      var field = schema[k];
+      if (!field || !field.relationship) {
+        var fakerPath = getFakerPath(field, k);
+        if (fakerPath) hasFaker = true;
+        a.push({
+          name: k,
+          fakerPath: fakerPath
+        });
+      }
+      return a;
+    }, []);
+
+    var schemaName = this.schemaName();
+    var schemaPath = '../../app/' + (options.pod ? schemaName : 'schemas') + '/' + (options.pod ? 'schema' : schemaName);
+
+    return {
+      fields: fields,
+      hasFaker: hasFaker,
+      schemaPath: schemaPath,
+      schemaName: schemaName,
+      modelName: this.modelName()
+    };
+  },
+
+  __name__: function(options) {
+    return options.pod ? 'model' : options.locals.modelName;
+  }
+};

--- a/blueprints/mirage-from-schema/index.js
+++ b/blueprints/mirage-from-schema/index.js
@@ -57,14 +57,15 @@ module.exports = {
     }, []);
 
     var schemaName = this.schemaName();
-    var schemaPath = '../../app/' + (options.pod ? schemaName : 'schemas') + '/' + (options.pod ? 'schema' : schemaName);
+    var modelName = this.modelName();
+    var schemaPath = '../../app/' + (options.pod ? modelName : 'schemas') + '/' + (options.pod ? 'schema' : schemaName);
 
     return {
       fields: fields,
       hasFaker: hasFaker,
       schemaPath: schemaPath,
       schemaName: schemaName,
-      modelName: this.modelName()
+      modelName: modelName
     };
   },
 

--- a/lib/addProductionPackagesToProject.js
+++ b/lib/addProductionPackagesToProject.js
@@ -34,11 +34,13 @@ module.exports = function addPackagesToProject(packages, prod) {
     save: !!prod
   };
 
-  // disable logger as per https://github.com/ember-cli/ember-cli/blob/master/lib/tasks/npm-task.js#L38
-  var oldLog = console.log;
-  console.log = function() {};
+  if (!this.options.testing) {
+    // disable logger as per https://github.com/ember-cli/ember-cli/blob/master/lib/tasks/npm-task.js#L38
+    var oldLog = console.log;
+    console.log = function() {};
 
-  return npm('install', packageArray, npmOptions).finally(() => {
-    console.log = oldLog;
-  });
+    return npm('install', packageArray, npmOptions).finally(() => {
+      console.log = oldLog;
+    });
+  }
 };

--- a/node-tests/blueprints/mirage-from-schema-test.js
+++ b/node-tests/blueprints/mirage-from-schema-test.js
@@ -1,0 +1,64 @@
+'use strict';
+var path = require('path');
+var fs = require('fs');
+
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerate = blueprintHelpers.emberGenerate;
+var setupPodConfig = blueprintHelpers.setupPodConfig;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var file = chai.file;
+var expect = chai.expect;
+
+describe('Acceptance: ember generate and destroy mirage from schema', function() {
+  setupTestHooks(this);
+
+  it('mirage-from-schema taco (simple)', function() {
+    var args = ['mirage-from-schema', 'taco'];
+
+    return emberNew()
+      .then(() => emberGenerate(['schema', 'taco', 'name:string', 'price:number', 'time:date', 'cheese:boolean', 'misc']))
+      .then(() => emberGenerateDestroy(args, (file) => {
+        var model = file('mirage/models/taco.js');
+        expect(model).to.contain("import tacos from '../../app/schemas/tacos';");
+        expect(model).to.contain("export default new JSONAPIMirageModel(tacos);");
+        var factory = file('mirage/factories/taco.js');
+        expect(factory).to.contain("import { Factory, faker } from 'ember-cli-mirage';");
+        expect(factory).to.contain("\"name\": function() { return faker.random.words(); }");
+        expect(factory).to.contain("\"price\": function() { return faker.random.number(); }");
+        expect(factory).to.contain("\"time\": function() { return faker.date.recent(); }");
+        expect(factory).to.contain("\"cheese\": function() { return faker.random.boolean(); }");
+        expect(factory).to.contain("\"misc\": null");
+    }));
+  });
+
+  it('mirage-from-schema taco (with pods)', function() {
+    var args = ['mirage-from-schema', 'taco'];
+
+    return emberNew()
+      .then(() => setupPodConfig({ usePods: true }))
+      .then(() => emberGenerate(['schema', 'taco', 'name:string', 'price:number', 'misc']))
+      .then(() => emberGenerateDestroy(args, (file) => {
+        var model = file('mirage/models/taco.js');
+        expect(model).to.contain("import tacos from '../../app/taco/schema';");
+    }));
+  });
+
+  // it('migration taco (relationships)', function() {
+  //   var args = ['migration', 'taco'];
+  //
+  //   return emberNew()
+  //     .then(() => emberGenerate(['schema', 'taco', 'filling:belongsTo:protein', 'toppings:hasMany:toppings']))
+  //     .then(() => emberGenerateDestroy(args, (file) => {
+  //       var migration = file('migrations/000001_tacos.js');
+  //       // we create foreign keys for our belongsTo relationships
+  //       expect(migration).to.contain("table.integer('filling_id');");
+  //       expect(migration).to.contain("table.foreign('filling_id').references('id').inTable('proteins');");
+  //       // we do not create keys for hasMany relationships, as they are defined by the child or in a join table.
+  //       expect(migration).to.not.contain("toppings");
+  //   }));
+  // });
+});

--- a/node-tests/blueprints/mirage-from-schema-test.js
+++ b/node-tests/blueprints/mirage-from-schema-test.js
@@ -23,7 +23,7 @@ describe('Acceptance: ember generate and destroy mirage from schema', function()
       .then(() => emberGenerate(['schema', 'taco', 'name:string', 'price:number', 'time:date', 'cheese:boolean', 'misc']))
       .then(() => emberGenerateDestroy(args, (file) => {
         var model = file('mirage/models/taco.js');
-        expect(model).to.contain("import tacos from '../../app/schemas/tacos';");
+        expect(model).to.contain("import tacos from 'my-app/schemas/tacos';");
         expect(model).to.contain("export default new JSONAPIMirageModel(tacos);");
         var factory = file('mirage/factories/taco.js');
         expect(factory).to.contain("import { Factory, faker } from 'ember-cli-mirage';");
@@ -43,7 +43,7 @@ describe('Acceptance: ember generate and destroy mirage from schema', function()
       .then(() => emberGenerate(['schema', 'taco', 'name:string', 'price:number', 'misc']))
       .then(() => emberGenerateDestroy(args, (file) => {
         var model = file('mirage/models/taco.js');
-        expect(model).to.contain("import tacos from '../../app/taco/schema';");
+        expect(model).to.contain("import tacos from 'my-app/taco/schema';");
     }));
   });
 

--- a/node-tests/blueprints/schema-test.js
+++ b/node-tests/blueprints/schema-test.js
@@ -18,7 +18,7 @@ describe('Acceptance: ember generate and destroy schema', function() {
       .then(() => emberGenerateDestroy(args, (file) => {
         var model = file('app/models/taco.js');
         expect(model).to.contain("import tacos from '../schemas/tacos';");
-        expect(model).to.contain("export default new JSONAPIModel(tacos)");
+        expect(model).to.contain("export default new JSONAPIModel(tacos);");
         var schema = file('app/schemas/tacos.json');
         expect(schema).to.contain("{}");
         var test = file('tests/unit/models/taco-test.js');
@@ -36,7 +36,7 @@ describe('Acceptance: ember generate and destroy schema', function() {
       .then(() => emberGenerateDestroy(args, (file) => {
         var model = file('app/taco/model.js');
         expect(model).to.contain("import tacos from './schema';");
-        expect(model).to.contain("export default new JSONAPIModel(tacos)");
+        expect(model).to.contain("export default new JSONAPIModel(tacos);");
         var schema = file('app/taco/schema.json');
         expect(schema).to.contain("{}");
         var test = file('tests/unit/taco/model-test.js');


### PR DESCRIPTION
Adds a `mirage-from-schema` generator for spinning up mirage models and factories based on jsonapi-schema schemas.

Resolves #3 

TODO:

- [x] documentation